### PR TITLE
fix(err-msg): display friendly duplicate email message

### DIFF
--- a/src/main/java/com/dogood/exception/ErrorResponse.java
+++ b/src/main/java/com/dogood/exception/ErrorResponse.java
@@ -4,10 +4,12 @@ import lombok.Getter;
 
 @Getter
 public class ErrorResponse {
+    private final String path;
     private final int status;
     private final String message;
 
-    public ErrorResponse(int status, String message) {
+    public ErrorResponse(String path, int status, String message) {
+        this.path = path;
         this.status = status;
         this.message = message;
     }

--- a/src/main/java/com/dogood/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dogood/exception/GlobalExceptionHandler.java
@@ -4,15 +4,28 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex, WebRequest req) {
         ErrorResponse body = new ErrorResponse(
+                req.getDescription(false),
                 HttpStatus.NOT_FOUND.value(),
                 ex.getMessage()
         );
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatusException(ResponseStatusException ex, WebRequest req) {
+        ErrorResponse body = new ErrorResponse(
+                req.getDescription(false),
+                ex.getStatusCode().value(),
+                ex.getReason()
+        );
+        return ResponseEntity.status(ex.getStatusCode()).body(body);
     }
 }

--- a/src/main/java/com/dogood/repository/UserRepository.java
+++ b/src/main/java/com/dogood/repository/UserRepository.java
@@ -7,4 +7,6 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     Users findByEmail(String email);
 
     Users findByResetToken(String resetToken);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/dogood/service/UserService.java
+++ b/src/main/java/com/dogood/service/UserService.java
@@ -10,7 +10,9 @@ import com.dogood.repository.UserRepository;
 import jakarta.transaction.Transactional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class UserService {
@@ -20,6 +22,8 @@ public class UserService {
     @Transactional
     public Users registerUser(Users users) {
         System.out.println("Registering users: " + users);
+        if(userRepository.existsByEmail(users.getEmail()))
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "User with email already exists");
         return userRepository.save(users);
     }
 


### PR DESCRIPTION
### **Summary**

- Resolve issue #26 and added a friendly err message if duplicate email is passed in
- Added a new handler(handleResponseStatusException) to GlobalExceptionHandler class
- Added an new field to ErrorResponse dto so errors are traceable 